### PR TITLE
Updated Version 1.0.1 and hash to SHA256

### DIFF
--- a/gitignorer.rb
+++ b/gitignorer.rb
@@ -1,9 +1,8 @@
-require 'formula'
-
 class Gitignorer < Formula
+  desc 'Easily create .gitignore files for your projects'
   homepage 'https://github.com/zachlatta/gitignorer'
-  url 'https://github.com/zachlatta/gitignorer/archive/v1.0.0.tar.gz'
-  sha1 'bb2726f86a7054cde3fc2713a3fecd8bd0334fed'
+  url 'https://github.com/zachlatta/gitignorer/archive/1.0.1.tar.gz'
+  sha256 '220c13b4359d74255ae2ed7d8ac8d8e4372aae5be41682ff50df3a0ecea91667'
 
   depends_on 'go' => :build
 
@@ -11,11 +10,11 @@ class Gitignorer < Formula
     ENV['GOPATH'] = buildpath
 
     directory = "github.com/zachlatta/gitignorer"
-    system "mkdir -p src/#{ directory }"
-    system "mv `ls -A | grep -v src` ./src/#{ directory }"
-    system "cd src/#{ directory }; go get"
+    system "mkdir -p src/#{directory}"
+    system "mv `ls -A | grep -v src` ./src/#{directory}"
+    system "cd src/#{directory}; go get"
 
-    system "cd src/#{ directory }; go install"
+    system "cd src/#{directory}; go install"
     bin.install 'bin/gitignorer'
   end
 


### PR DESCRIPTION
Since homebrew version 1.1.0 the support for SHA1 is disabled. Upgrading with brew results with gitignorer therefore in an error:
```
Error: Calling Formula.sha1 is disabled!
Use Formula.sha256 instead.
/usr/local/Homebrew/Library/Taps/zachlatta/homebrew-gitignorer/gitignorer.rb:6:in `<class:Gitignorer>'
```

The PR upgrades to version 1.0.1 and replaced the SHA1 with SHA256 among other small linter related changes.